### PR TITLE
Bump latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ lint:
 	golangci-lint run
 
 license:
-	go install github.com/AbsaOSS/golic@v0.6.0
+	go install github.com/AbsaOSS/golic@latest
 	golic inject -c="2022 Absa Group Limited"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ golic inject -c="2022 MyCompany ltd." --dry
 Install and run **GOLIC**
 ```shell
 # GO 1.16 
-go install github.com/AbsaOSS/golic@v0.6.0
+go install github.com/AbsaOSS/golic@latest
 golic version
 ```
 Golic has two configurations `.licignore` and `.golic.yaml`. The first determines which 
@@ -72,7 +72,7 @@ Usually you want to find out that something went wrong during CI / CD. For examp
 In terms of golic, we want the build pipe to end with an error if we find at least one file with a missing license.
 The `-x` argument handles that.
 ```shell
-  go install github.com/AbsaOSS/golic@v0.6.0
+  go install github.com/AbsaOSS/golic@latest
   golic inject --dry -x -t apache2
 ```
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "v0.6.0"
+const version = "v0.7.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
I didn't remove tag properly and seems it's reason I can't run sucesfully `go install github.com/AbsaOSS/golic@v0.7.0`, but I can sucesfully install from my forked test. Seems I need to rerelease one more time.

On this occasion I am making minor adjustments.


Signed-off-by: kuritka <kuritka@gmail.com>